### PR TITLE
Allow helpers to required via 'require openc_bot/helpers'

### DIFF
--- a/lib/openc_bot/helpers.rb
+++ b/lib/openc_bot/helpers.rb
@@ -1,0 +1,3 @@
+Dir[File.join(File.dirname(__FILE__), 'helpers', '*.rb')].each do |f|
+  require f
+end

--- a/lib/openc_bot/helpers/csv.rb
+++ b/lib/openc_bot/helpers/csv.rb
@@ -1,5 +1,3 @@
-# This is in _csr.rb to avoid requiring it when we mean to require the system
-# csv library.
 module OpencBot
   module Helpers
     module Csv

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = ['openc_bot']
 
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib",'lib/openc_bot/helpers']
+  gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport"
   gem.add_dependency "nokogiri"


### PR DESCRIPTION
I think this is the correct way to allow users of openc_bot to optionally require all helpers (`require openc_bot/helpers`) or a single helper (`require openc_bot/helpers/csv`).