### PR TITLE
Allowed hours

### DIFF
--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -64,7 +64,7 @@ module OpencBot
       update_data_results = update_data(options.merge(:started_at => start_time)) || {}
       # we may get a string back, or something else
       update_data_results = {:output => update_data_results.to_s} unless update_data_results.is_a?(Hash)
-      report_run_results(update_data_results.merge(:started_at => start_time, :ended_at => Time.now, :status_code => '1', :git_commit => current_git_commit))
+      report_run_results(update_data_results.merge(:started_at => start_time, :ended_at => Time.now, :status_code => '1'))
     end
 
     def schema_name
@@ -116,7 +116,7 @@ module OpencBot
     def report_run_to_oc(params)
       bot_id = self.to_s.underscore
       run_params = params.slice!(RUN_ATTRIBUTES)
-      run_params.merge!(:bot_id => bot_id, :bot_type => 'external')
+      run_params.merge!(:bot_id => bot_id, :bot_type => 'external', :git_commit => current_git_commit)
       run_params[:output] ||= params.to_s unless params.blank?
       _http_post(OC_RUN_REPORT_URL, {:run => run_params})
     rescue Exception => e

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -24,8 +24,8 @@ module OpencBot
     STDOUT.sync = true
     STDERR.sync = true
     # This is called by #update_datum
-    def fetch_datum(company_number)
-      company_page = fetch_registry_page(company_number)
+    def fetch_datum(company_number,options={})
+      company_page = fetch_registry_page(company_number, options)
       {:company_page => company_page}
     end
 

--- a/lib/openc_bot/exceptions.rb
+++ b/lib/openc_bot/exceptions.rb
@@ -7,6 +7,8 @@ module OpencBot
 
   class OutOfPermittedHours < OpencBotError; end
 
+  class SourceClosedForMaintenance < OpencBotError; end
+
   #
   # Raised by <tt>save_entity!</tt> when the record is invalid.
   # Use the +validation_errors+ method to retrieve the, er, validation errors.

--- a/lib/openc_bot/exceptions.rb
+++ b/lib/openc_bot/exceptions.rb
@@ -5,6 +5,8 @@ module OpencBot
 
   class SingleRecordUpdateNotImplemented < OpencBotError; end
 
+  class OutOfPermittedHours < OpencBotError; end
+
   #
   # Raised by <tt>save_entity!</tt> when the record is invalid.
   # Use the +validation_errors+ method to retrieve the, er, validation errors.

--- a/lib/openc_bot/helpers/register_methods.rb
+++ b/lib/openc_bot/helpers/register_methods.rb
@@ -251,6 +251,8 @@ module OpencBot
           count += 1
         end
         {:updated => count}
+      rescue OutOfPermittedHours, SourceClosedForMaintenance => e
+        {:updated => count, :output => e.message}
       end
 
       def validate_datum(record)

--- a/lib/openc_bot/helpers/register_methods.rb
+++ b/lib/openc_bot/helpers/register_methods.rb
@@ -10,6 +10,10 @@ module OpencBot
     module RegisterMethods
       MAX_BUSY_RETRIES = 3
 
+      def allowed_hours
+        self.const_defined?('ALLOWED_HOURS') && self.const_get('ALLOWED_HOURS')
+      end
+
       def use_alpha_search
         self.const_defined?('USE_ALPHA_SEARCH') && self.const_get('USE_ALPHA_SEARCH')
       end
@@ -54,6 +58,12 @@ module OpencBot
       def fetch_registry_page(company_number)
         sleep_before_http_req
         _client.get_content(registry_url(company_number))
+      end
+
+      def in_prohibited_time?
+        current_time = Time.now
+
+        allowed_hours && !allowed_hours.include?(current_time.hour)# || current_time.saturday? || current_time.sunday?
       end
 
       def prepare_and_save_data(all_data,options={})

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "scraperwiki", "3.0.2"
   gem.add_dependency "mail"
   gem.add_dependency "retriable", "~> 2.1"
+  gem.add_dependency "tzinfo"
   # gem.add_dependency "openc-asana" unless RUBY_VERSION < '2.0'
 
   # gem.add_development_dependency "perftools.rb"

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -157,6 +157,15 @@ describe "A module that extends CompanyFetcherBot" do
       result = TestCompaniesFetcher.update_data
       result.should == {:added => 3, :updated => 42}
     end
+
+    context 'and Exception raised' do
+      it 'should send error report with options passed in to update_data' do
+        exception = RuntimeError.new('something went wrong')
+        TestCompaniesFetcher.stub(:fetch_data).and_raise(exception)
+        TestCompaniesFetcher.should_receive(:send_error_report).with(exception, :foo => 'bar')
+        result = TestCompaniesFetcher.update_data(:foo => 'bar')
+      end
+    end
   end
 
   describe '#run' do

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -163,7 +163,7 @@ describe "A module that extends CompanyFetcherBot" do
         exception = RuntimeError.new('something went wrong')
         TestCompaniesFetcher.stub(:fetch_data).and_raise(exception)
         TestCompaniesFetcher.should_receive(:send_error_report).with(exception, :foo => 'bar')
-        result = TestCompaniesFetcher.update_data(:foo => 'bar')
+        lambda{TestCompaniesFetcher.update_data(:foo => 'bar')}.should raise_error(exception)
       end
     end
   end

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -45,13 +45,20 @@ describe "A module that extends CompanyFetcherBot" do
     end
 
     it "should #fetch_registry_page for company_numbers" do
-      TestCompaniesFetcher.should_receive(:fetch_registry_page).with('76543')
+      TestCompaniesFetcher.should_receive(:fetch_registry_page).with('76543',{})
       TestCompaniesFetcher.fetch_datum('76543')
     end
 
     it "should stored result of #fetch_registry_page in hash keyed to :company_page" do
       TestCompaniesFetcher.stub(:fetch_registry_page).and_return(:registry_page_html)
       TestCompaniesFetcher.fetch_datum('76543').should == {:company_page => :registry_page_html}
+    end
+
+    context 'and options passed in' do
+      it 'should pass on to fetch_registry_page' do
+        TestCompaniesFetcher.should_receive(:fetch_registry_page).with('76543', :foo => 'bar')
+        TestCompaniesFetcher.fetch_datum('76543', :foo => 'bar')
+      end
     end
   end
 

--- a/spec/lib/helpers/register_methods_spec.rb
+++ b/spec/lib/helpers/register_methods_spec.rb
@@ -656,6 +656,33 @@ describe 'a module that includes RegisterMethods' do
     end
   end
 
+  describe 'in_prohibited_time?' do
+    before do
+      ModuleThatIncludesRegisterMethods.stub(:allowed_hours).and_return((0..12))
+    end
+
+    after do
+      Time.unstub(:now)
+    end
+
+    it 'should return true only for out of office hours' do
+      times_and_truthiness = {
+        "2014-10-09 10:14:25 +0100" => false, # in time span
+        # "2014-10-11 15:14:25 +0100" => true, # in weekend
+        "2014-10-10 15:14:25 +0100" => true # weekday working time in hours
+      }
+      times_and_truthiness.each do |datetime, truthiness|
+        Time.stub(:now).and_return(Time.parse(datetime))
+        ModuleThatIncludesRegisterMethods.in_prohibited_time?.should == truthiness
+      end
+    end
+
+    it 'should return nil if allowed_hours not defined' do
+      Time.stub(:now).and_return(Time.parse("2014-10-10 15:14:25 +0100"))
+      ModuleWithNoCustomPrimaryKey.in_prohibited_time?.should be_false
+    end
+  end
+
   describe 'raise_when_saving_invalid_record' do
     it 'should return false if RAISE_WHEN_SAVING_INVALID_RECORD not set' do
       ModuleWithNoCustomPrimaryKey.send(:raise_when_saving_invalid_record).should == false

--- a/spec/lib/helpers/register_methods_spec.rb
+++ b/spec/lib/helpers/register_methods_spec.rb
@@ -171,6 +171,36 @@ describe 'a module that includes RegisterMethods' do
       ModuleThatIncludesRegisterMethods.stub(:update_datum)
       ModuleThatIncludesRegisterMethods.update_stale.should == {:updated => 3}
     end
+
+    context 'and OutOfPermittedHours raised' do
+      before do
+        @exception = OpencBot::OutOfPermittedHours.new('not supposed to be running')
+      end
+
+      it 'should return number updated and exception message' do
+        ModuleThatIncludesRegisterMethods.stub(:stale_entry_uids).
+          and_yield('234').
+          and_yield('666').
+          and_raise(@exception)
+        ModuleThatIncludesRegisterMethods.stub(:update_datum)
+        ModuleThatIncludesRegisterMethods.update_stale.should == { :updated => 2, :output => @exception.message }
+      end
+    end
+
+    context 'and SourceClosedForMaintenance raised' do
+      before do
+        @exception = OpencBot::SourceClosedForMaintenance.new('site is down')
+      end
+
+      it 'should return number updated and exception message' do
+        ModuleThatIncludesRegisterMethods.stub(:stale_entry_uids).
+          and_yield('234').
+          and_yield('666').
+          and_raise(@exception)
+        ModuleThatIncludesRegisterMethods.stub(:update_datum)
+        ModuleThatIncludesRegisterMethods.update_stale.should == { :updated => 2, :output => @exception.message }
+      end
+    end
   end
 
   describe "#stale_entry_uids" do

--- a/spec/lib/helpers/register_methods_spec.rb
+++ b/spec/lib/helpers/register_methods_spec.rb
@@ -656,6 +656,24 @@ describe 'a module that includes RegisterMethods' do
     end
   end
 
+  describe 'allowed_hours' do
+    it "should return ALLOWED_HOURS if ALLOWED_HOURS defined" do
+      stub_const("ModuleThatIncludesRegisterMethods::ALLOWED_HOURS", (2..5))
+      ModuleThatIncludesRegisterMethods.allowed_hours.should == [2,3,4,5]
+    end
+
+    it "should return nil if ALLOWED_HOURS not defined" do
+      ModuleThatIncludesRegisterMethods.allowed_hours.should be_nil
+    end
+
+    context 'and TIMEZONE defined' do
+      it "should return non-working hours in timezone" do
+        stub_const("ModuleThatIncludesRegisterMethods::TIMEZONE", 'America/Panama')
+        ModuleThatIncludesRegisterMethods.allowed_hours.should == [23,24,0,1,2,3,4,5,6,7,8,9,10,11,12,13]
+      end
+    end
+  end
+
   describe 'in_prohibited_time?' do
     before do
       ModuleThatIncludesRegisterMethods.stub(:allowed_hours).and_return((0..12))
@@ -677,7 +695,7 @@ describe 'a module that includes RegisterMethods' do
       end
     end
 
-    it 'should return nil if allowed_hours not defined' do
+    it 'should return false if allowed_hours not defined' do
       Time.stub(:now).and_return(Time.parse("2014-10-10 15:14:25 +0100"))
       ModuleWithNoCustomPrimaryKey.in_prohibited_time?.should be_false
     end

--- a/spec/lib/helpers/register_methods_spec.rb
+++ b/spec/lib/helpers/register_methods_spec.rb
@@ -699,7 +699,7 @@ describe 'a module that includes RegisterMethods' do
     it 'should return false if allowed_hours not defined' do
       parsed_time = Time.parse("2014-10-10 15:14:25 +0100")
       Time.stub(:now).and_return(parsed_time)
-      ModuleWithNoCustomPrimaryKey.in_prohibited_time?.should be_false
+      ModuleWithNoCustomPrimaryKey.in_prohibited_time?.should be_nil
     end
   end
 

--- a/spec/lib/helpers/register_methods_spec.rb
+++ b/spec/lib/helpers/register_methods_spec.rb
@@ -690,13 +690,15 @@ describe 'a module that includes RegisterMethods' do
         "2014-10-10 15:14:25 +0100" => true # weekday working time in hours
       }
       times_and_truthiness.each do |datetime, truthiness|
-        Time.stub(:now).and_return(Time.parse(datetime))
+        parsed_time = Time.parse(datetime)
+        Time.stub(:now).and_return(parsed_time)
         ModuleThatIncludesRegisterMethods.in_prohibited_time?.should == truthiness
       end
     end
 
     it 'should return false if allowed_hours not defined' do
-      Time.stub(:now).and_return(Time.parse("2014-10-10 15:14:25 +0100"))
+      parsed_time = Time.parse("2014-10-10 15:14:25 +0100")
+      Time.stub(:now).and_return(parsed_time)
       ModuleWithNoCustomPrimaryKey.in_prohibited_time?.should be_false
     end
   end


### PR DESCRIPTION
Usage:
Set timezone in bot:
e.g. 
```
module PaCompaniesFetcher
  TIMEZONE = 'America/Panama'

```
and then when making http_request (e.g. from alpha search)
`_http_get_with_retry(url, :restrict_to_out_of_hours=>true)
`
Recommended only to use in long-running processes (e.g. alpha or incremental search) rather than all update_datum (which may be called by update from register)
