### PR TITLE
Fix dependency issues with our other gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 rvm:
+  - "1.9.3"
   - "2.0.0"
   - "2.1.0"
   - "2.2.0"

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.63"
+  VERSION = "0.0.64"
 end

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -34,7 +34,11 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rake"
   gem.add_dependency "activesupport", "4.1.4"
-  gem.add_dependency "nokogiri"
+  if RUBY_VERSION < '2.1'
+    gem.add_dependency "nokogiri", "< 1.7.0"
+  else
+    gem.add_dependency "nokogiri"
+  end
   gem.add_dependency "sqlite_magic", "0.0.6"
   gem.add_dependency "json"
   gem.add_dependency "json-schema"

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.executables   = ['openc_bot']
 
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib",'lib/openc_bot/helpers']
+  gem.require_paths = ["lib"]
 
   gem.add_dependency "rake"
   gem.add_dependency "activesupport", "4.1.4"

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "retriable", "~> 2.1"
   gem.add_dependency "tzinfo"
   # gem.add_dependency "openc-asana" unless RUBY_VERSION < '2.0'
+  gem.add_dependency "addressable", "< 2.5.0" if RUBY_VERSION < '2.0' # via `json-schema`
 
   # gem.add_development_dependency "perftools.rb"
   gem.add_development_dependency "byebug" unless RUBY_VERSION < '2.0'

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -45,11 +45,14 @@ Gem::Specification.new do |gem|
   gem.add_dependency "httpclient"
   gem.add_dependency "backports"
   gem.add_dependency "scraperwiki", "3.0.2"
-  gem.add_dependency "mail"
+  gem.add_dependency "mail", "~> 2.0"
   gem.add_dependency "retriable", "~> 2.1"
   gem.add_dependency "tzinfo"
   # gem.add_dependency "openc-asana" unless RUBY_VERSION < '2.0'
-  gem.add_dependency "addressable", "< 2.5.0" if RUBY_VERSION < '2.0' # via `json-schema`
+  if RUBY_VERSION < '2.0'
+    gem.add_dependency "addressable", "< 2.5.0" # via `json-schema`
+    gem.add_dependency "mime-types", "< 3.0" # via `mail`
+  end
 
   # gem.add_development_dependency "perftools.rb"
   gem.add_development_dependency "byebug" unless RUBY_VERSION < '2.0'

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "rake"
-  gem.add_dependency "activesupport", "4.1.4"
+  gem.add_dependency "activesupport", "~> 4.1"
   if RUBY_VERSION < '2.1'
     gem.add_dependency "nokogiri", "< 1.7.0"
   else


### PR DESCRIPTION
Directories specified in `required_paths` are added to the load paths of projects that include this gem. This results in namespace conflicts with gems that share the name of files in `lib/openc_bot/helpers`, for example the `text` gem.