### PR TITLE
Remove conditional dependencies from gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - "1.9.3"
-  - "2.0.0"
-  - "2.1.0"
   - "2.2.0"
 before_install:
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 rvm:
-  - "2.2.0"
+  - "2.2"
 before_install:
   - gem update --system
   - gem update bundler

--- a/lib/openc_bot/templates/spec/spec_helper.rb
+++ b/lib/openc_bot/templates/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'rspec/autorun'
-require 'debugger'
 
 RSpec.configure do |config|
 

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.65"
+  VERSION = "0.0.66"
 end

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -34,11 +34,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rake"
   gem.add_dependency "activesupport", "~> 4.1"
-  if RUBY_VERSION < '2.1'
-    gem.add_dependency "nokogiri", "< 1.7.0"
-  else
-    gem.add_dependency "nokogiri"
-  end
+  gem.add_dependency "nokogiri"
   gem.add_dependency "sqlite_magic", "0.0.6"
   gem.add_dependency "json"
   gem.add_dependency "json-schema"
@@ -48,14 +44,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mail", "~> 2.0"
   gem.add_dependency "retriable", "~> 2.1"
   gem.add_dependency "tzinfo"
-  # gem.add_dependency "openc-asana" unless RUBY_VERSION < '2.0'
-  if RUBY_VERSION < '2.0'
-    gem.add_dependency "addressable", "< 2.5.0" # via `json-schema`
-    gem.add_dependency "mime-types", "< 3.0" # via `mail`
-  end
 
   # gem.add_development_dependency "perftools.rb"
-  gem.add_development_dependency "byebug" unless RUBY_VERSION < '2.0'
-  gem.add_development_dependency "debugger" if RUBY_VERSION < '2.0'
+  gem.add_development_dependency "byebug"
   gem.add_development_dependency "rspec"
 end

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = '~> 2.2.0'
   gem.add_dependency "rake"
   gem.add_dependency "activesupport", "~> 4.1"
   gem.add_dependency "nokogiri"

--- a/spec/schemas/company-schema_spec.rb
+++ b/spec/schemas/company-schema_spec.rb
@@ -2,7 +2,6 @@
 require 'json-schema'
 require 'active_support'
 require 'active_support/core_ext'
-# require 'debugger'
 
 describe 'company-schema' do
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # require 'rspec/autorun'
-if RUBY_VERSION >= '2.0'
-  require 'byebug'
-end
+require 'byebug'
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
The gemspec is evaluated at build time so `RUBY_VERSION` is always whatever version of ruby the builder is currently using, not the user.

This commit removes support for ruby versions less than 2.1. Projects still using previous versions of `openc_bot` can continue to do so.