### PR TITLE
Swap to report to analysis app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.67)
+    openc_bot (0.0.68)
       activesupport (~> 4.1)
       backports (~> 3.11)
       httpclient (~> 2.8)

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -10,7 +10,7 @@ module OpencBot
     include OpencBot::Helpers::IncrementalSearch
     include OpencBot::Helpers::AlphaSearch
     # this is only available inside the VPN
-    OC_RUN_REPORT_URL = "https://opencorporates.com/runs".freeze
+    ANALYSIS_RUN_REPORT_URL = "https://analysis.opencorporates.com/runs".freeze
     RUN_ATTRIBUTES = %i[
       started_at
       ended_at
@@ -38,7 +38,7 @@ module OpencBot
 
     def report_run_results(results)
       send_run_report(results)
-      report_run_to_oc(results)
+      report_run_to_analysis_app(results)
     end
 
     # This overrides default #save_entity (defined in RegisterMethods) and adds
@@ -94,7 +94,7 @@ module OpencBot
       subject = "Error running #{name}: #{e}"
       body = "Error details: #{e.inspect}.\nBacktrace:\n#{e.backtrace}"
       send_report(subject: subject, body: body)
-      report_run_to_oc(output: body, status_code: "0", ended_at: Time.now.to_s, started_at: options[:started_at])
+      report_run_to_analysis_app(output: body, status_code: "0", ended_at: Time.now.to_s, started_at: options[:started_at])
     end
 
     def send_run_report(run_results = nil)
@@ -114,12 +114,12 @@ module OpencBot
       end
     end
 
-    def report_run_to_oc(params)
+    def report_run_to_analysis_app(params)
       bot_id = to_s.underscore
       run_params = params.slice!(RUN_ATTRIBUTES)
       run_params.merge!(bot_id: bot_id, bot_type: "external", git_commit: current_git_commit)
       run_params[:output] ||= params.to_s unless params.blank?
-      _http_post(OC_RUN_REPORT_URL, run: run_params)
+      _http_post(ANALYSIS_RUN_REPORT_URL, run: run_params)
     rescue Exception => e
       puts "Exception (#{e.inspect}) reporting run to OpenCorporates"
     end

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -124,9 +124,8 @@ module OpencBot
       puts "Exception (#{e.inspect}) reporting run to OpenCorporates"
     end
 
-    def _http_post(_url, params)
-      # this will (correctly) fail in development as it will be outside internal IP range
-      _client.post(OC_RUN_REPORT_URL, params.to_query)
+    def _http_post(url, params)
+      _client.post(url, params.to_query)
     end
   end
 end

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -124,6 +124,9 @@ module OpencBot
       puts "Exception (#{e.inspect}) reporting run to OpenCorporates"
     end
 
+    # DEPRECATED. Please use report_run_to_analysis_app instead of report_run_to_oc
+    alias report_run_to_oc report_run_to_analysis_app
+
     def _http_post(url, params)
       _client.post(url, params.to_query)
     end

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.67".freeze
+  VERSION = "0.0.68".freeze
 end

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -198,4 +198,10 @@ describe "A module that extends CompanyFetcherBot" do
       TestCompaniesFetcher.run
     end
   end
+
+  describe "#report_run_to_oc" do
+    it "supports this deprecated method (called by many external bots) but actually sends a report to the analysis app" do
+      expect(TestCompaniesFetcher.method(:report_run_to_oc)).to eq(TestCompaniesFetcher.method(:report_run_to_analysis_app))
+    end
+  end
 end

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -190,9 +190,11 @@ describe "A module that extends CompanyFetcherBot" do
       TestCompaniesFetcher.run
     end
 
-    it "posts report to OpenCorporates" do
-      expected_params = { run: hash_including(foo: "bar", bot_id: "test_companies_fetcher", bot_type: "external", status_code: "1", git_commit: "abc12345") }
-      expect(TestCompaniesFetcher).to receive(:_http_post).with(OpencBot::CompanyFetcherBot::OC_RUN_REPORT_URL, expected_params)
+    it "posts report to the analysis app" do
+      expected_params = {
+        run: hash_including(foo: "bar", bot_id: "test_companies_fetcher", bot_type: "external", status_code: "1", git_commit: "abc12345"),
+      }
+      expect(TestCompaniesFetcher).to receive(:_http_post).with(OpencBot::CompanyFetcherBot::ANALYSIS_RUN_REPORT_URL, expected_params)
       TestCompaniesFetcher.run
     end
   end


### PR DESCRIPTION
From now on we want to send run reports direct to the new analysis app at http://analysis.opencorporates.com . This is the relocated new home of run data features previously part of opencorporates.com (private admin areas)

https://opencorporates.atlassian.net/browse/OCD-1674