### PR TITLE
Progress reporting to analysis app

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -56,7 +56,7 @@ Metrics/MethodLength:
 
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 278
+  Max: 280
 
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.68)
+    openc_bot (0.0.69)
       activesupport (~> 4.1)
       backports (~> 3.11)
       httpclient (~> 2.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    json (2.2.0)
+    json (2.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     mail (2.7.1)
@@ -53,7 +53,7 @@ GEM
     minitest (5.13.0)
     nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pry (0.12.2)
@@ -89,7 +89,7 @@ GEM
     scraperwiki (3.0.2)
       httpclient
       sqlite_magic
-    sqlite3 (1.4.1)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -126,8 +126,12 @@ module OpencBot
     # DEPRECATED. Please use report_run_to_analysis_app instead of report_run_to_oc
     alias report_run_to_oc report_run_to_analysis_app
 
+    def _analysis_app_client
+      @analysis_app_client ||= _client(connect_timeout: 5, receive_timeout: 10, flush_client: true)
+    end
+
     def _http_post(url, params)
-      _client.post(url, params.to_query)
+      _analysis_app_client.post(url, params.to_query)
     end
   end
 end

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -40,6 +40,10 @@ module OpencBot
       report_run_to_analysis_app(results)
     end
 
+    def report_run_progress(companies_processed:, companies_added: nil, companies_updated: nil)
+      report_progress_to_analysis_app(companies_processed: companies_processed, companies_added: companies_added, companies_updated: companies_updated)
+    end
+
     # This overrides default #save_entity (defined in RegisterMethods) and adds
     # the inferred jurisdiction_code, unless it is overridden in entity_info
     def save_entity(entity_info)
@@ -125,6 +129,18 @@ module OpencBot
 
     # DEPRECATED. Please use report_run_to_analysis_app instead of report_run_to_oc
     alias report_run_to_oc report_run_to_analysis_app
+
+    def report_progress_to_analysis_app(companies_processed:, companies_added: nil, companies_updated: nil)
+      data = {
+        "bot_id" => to_s.underscore,
+        "companies_processed" => companies_processed,
+        "companies_added" => companies_added,
+        "companies_updated" => companies_updated,
+      }
+      _http_post("#{ANALYSIS_HOST}/fetcher_progress_log", data: data.to_json)
+    rescue Exception => e
+      puts "Exception (#{e.inspect}) reporting progress to analysis app"
+    end
 
     def _analysis_app_client
       @analysis_app_client ||= _client(connect_timeout: 5, receive_timeout: 10, flush_client: true)

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -9,7 +9,7 @@ module OpencBot
     include OpencBot::Helpers::IncrementalSearch
     include OpencBot::Helpers::AlphaSearch
     # this is only available inside the VPN
-    ANALYSIS_RUN_REPORT_URL = "https://analysis.opencorporates.com/runs".freeze
+    ANALYSIS_HOST = "https://analysis.opencorporates.com".freeze
     RUN_ATTRIBUTES = %i[
       started_at
       ended_at
@@ -118,7 +118,7 @@ module OpencBot
       run_params = params.slice!(RUN_ATTRIBUTES)
       run_params.merge!(bot_id: bot_id, bot_type: "external", git_commit: current_git_commit)
       run_params[:output] ||= params.to_s unless params.blank?
-      _http_post(ANALYSIS_RUN_REPORT_URL, run: run_params)
+      _http_post("#{ANALYSIS_HOST}/runs", run: run_params)
     rescue Exception => e
       puts "Exception (#{e.inspect}) reporting run to analysis app"
     end

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -120,7 +120,7 @@ module OpencBot
       run_params[:output] ||= params.to_s unless params.blank?
       _http_post(ANALYSIS_RUN_REPORT_URL, run: run_params)
     rescue Exception => e
-      puts "Exception (#{e.inspect}) reporting run to OpenCorporates"
+      puts "Exception (#{e.inspect}) reporting run to analysis app"
     end
 
     # DEPRECATED. Please use report_run_to_analysis_app instead of report_run_to_oc

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -1,7 +1,6 @@
 require "openc_bot"
 require "openc_bot/helpers/incremental_search"
 require "openc_bot/helpers/alpha_search"
-# require 'openc_bot/asana_notifier'
 require "mail"
 
 module OpencBot

--- a/lib/openc_bot/helpers/register_methods.rb
+++ b/lib/openc_bot/helpers/register_methods.rb
@@ -333,6 +333,8 @@ module OpencBot
         @client = HTTPClient.new(options.delete(:proxy))
         @client.ssl_config.verify_mode = OpenSSL::SSL::VERIFY_NONE if options.delete(:skip_ssl_verification)
         @client.agent_name = options.delete(:user_agent)
+        @client.connect_timeout = options.delete(:connect_timeout)
+        @client.receive_timeout = options.delete(:receive_timeout)
         @client.ssl_config.ssl_version = options.delete(:ssl_version) if options[:ssl_version]
         if ssl_certificate = options.delete(:ssl_certificate)
           @client.ssl_config.add_trust_ca(ssl_certificate) # Above cert

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.68".freeze
+  VERSION = "0.0.69".freeze
 end

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -190,12 +190,26 @@ describe "A module that extends CompanyFetcherBot" do
       TestCompaniesFetcher.run
     end
 
-    it "posts report to the analysis app" do
+    it "posts a run report to the analysis app" do
       expected_params = {
         run: hash_including(foo: "bar", bot_id: "test_companies_fetcher", bot_type: "external", status_code: "1", git_commit: "abc12345"),
       }
       expect(TestCompaniesFetcher).to receive(:_http_post).with("#{OpencBot::CompanyFetcherBot::ANALYSIS_HOST}/runs", expected_params)
       TestCompaniesFetcher.run
+    end
+  end
+
+  describe "#report_run_progress" do
+    it "posts a progress report to the analysis app fetcher_progress_log endpoint" do
+      expected_params = { data: { bot_id: "test_companies_fetcher", companies_processed: 3, companies_added: 2, companies_updated: 1 }.to_json }
+      expect(TestCompaniesFetcher).to receive(:_http_post).with("#{OpencBot::CompanyFetcherBot::ANALYSIS_HOST}/fetcher_progress_log", expected_params)
+      TestCompaniesFetcher.report_run_progress(companies_processed: 3, companies_added: 2, companies_updated: 1)
+    end
+
+    it "posts null values in the json payload for absent stats" do
+      expected_params = { data: { bot_id: "test_companies_fetcher", companies_processed: 3, companies_added: nil, companies_updated: nil }.to_json }
+      expect(TestCompaniesFetcher).to receive(:_http_post).with("#{OpencBot::CompanyFetcherBot::ANALYSIS_HOST}/fetcher_progress_log", expected_params)
+      TestCompaniesFetcher.report_run_progress(companies_processed: 3)
     end
   end
 

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -194,7 +194,7 @@ describe "A module that extends CompanyFetcherBot" do
       expected_params = {
         run: hash_including(foo: "bar", bot_id: "test_companies_fetcher", bot_type: "external", status_code: "1", git_commit: "abc12345"),
       }
-      expect(TestCompaniesFetcher).to receive(:_http_post).with(OpencBot::CompanyFetcherBot::ANALYSIS_RUN_REPORT_URL, expected_params)
+      expect(TestCompaniesFetcher).to receive(:_http_post).with("#{OpencBot::CompanyFetcherBot::ANALYSIS_HOST}/runs", expected_params)
       TestCompaniesFetcher.run
     end
   end


### PR DESCRIPTION
Provide a new `report_progress_to_analysis_app` method alongside `report_run_to_analysis_app`, and a public method which calls this called `report_run_progress` alongside the existing `report_run_results`.

Some other tidying and set http timeouts on analysis app calls.

https://opencorporates.atlassian.net/browse/OCD-1882