### PR TITLE
Remove debugger gem reference in template

### DIFF
--- a/lib/openc_bot/tasks.rb
+++ b/lib/openc_bot/tasks.rb
@@ -162,10 +162,9 @@ namespace :bot do
       end
     end
 
-    # Add rspec debugger to gemfile
     File.open(File.join(working_dir, "Gemfile"), "a") do |file|
-      file.puts "group :test do\n  gem 'rspec'\n  gem 'debugger'\nend"
-      puts "Added rspec and debugger to Gemfile at #{file}"
+      file.puts "group :test do\n  gem 'rspec'\n  gem 'byebug'\nend"
+      puts "Added rspec and byebug to Gemfile at #{file}"
     end
     puts "Please run 'bundle install'"
   end


### PR DESCRIPTION
Remove debugger gem reference in template

In the task which creates a template bot Gemfile, swap out `debugger` gem for `byebug` which will work with later rubies (https://stackoverflow.com/a/29332267/338265 )

Note: This is only template example bot code, and it's not clear if anyone would create from the template like this any more. This has been preventing it running

~~(We do also need to remove `debugger` requires from various bots)~~  `debugger` requires have been removed from the various real bot code: https://github.com/openc/external_bots/pull/2557