### PR TITLE
Fetcher progress reporting

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,6 @@ Lint/RescueException:
     - 'lib/openc_bot/company_fetcher_bot.rb'
     - 'lib/openc_bot/helpers/alpha_search.rb'
     - 'lib/openc_bot/helpers/register_methods.rb'
-    - 'lib/openc_bot/helpers/reporting.rb'
     - 'lib/openc_bot/tasks.rb'
 
 Lint/ShadowedException:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.74)
+    openc_bot (0.0.75)
       activesupport (~> 4.1)
       backports (~> 3.11)
       httpclient (~> 2.8)

--- a/lib/openc_bot.rb
+++ b/lib/openc_bot.rb
@@ -84,7 +84,7 @@ module OpencBot
       StatsD.server = "sys1:8125"
       StatsD.logger = Logger.new("/dev/null") if bot_env == :test
 
-      if respond_to?(:inferred_jurisdiction_code)
+      if respond_to?(:inferred_jurisdiction_code) && inferred_jurisdiction_code
         "fetcher_bot.#{bot_env}.#{inferred_jurisdiction_code}"
       elsif is_a?(Module)
         "fetcher_bot.#{bot_env}.#{name.downcase}"

--- a/lib/openc_bot/helpers/register_methods.rb
+++ b/lib/openc_bot/helpers/register_methods.rb
@@ -92,7 +92,6 @@ module OpencBot
         # fail_count, retry_interval = 0, 5
         begin
           res = insert_or_update([primary_key_name], data_to_be_saved)
-          StatsD.increment("#{statsd_namespace}.processed", sample_rate: 1.0)
           track_company_processed
           res
         rescue SQLite3::BusyException => e

--- a/lib/openc_bot/helpers/register_methods.rb
+++ b/lib/openc_bot/helpers/register_methods.rb
@@ -1,14 +1,17 @@
 require "json-schema"
 require "active_support"
 require "active_support/core_ext"
-require "openc_bot/exceptions"
 require "retriable"
 require "tzinfo"
 require "English"
+require "openc_bot/exceptions"
+require "openc_bot/helpers/reporting"
 
 module OpencBot
   module Helpers
     module RegisterMethods
+      include OpencBot::Helpers::Reporting
+
       MAX_BUSY_RETRIES = 3
 
       def allowed_hours
@@ -90,6 +93,7 @@ module OpencBot
         begin
           res = insert_or_update([primary_key_name], data_to_be_saved)
           StatsD.increment("#{statsd_namespace}.processed", sample_rate: 1.0)
+          track_company_processed
           res
         rescue SQLite3::BusyException => e
           # fail_count += 1

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -9,6 +9,8 @@ module OpencBot
       # this is only available inside the VPN
       ANALYSIS_HOST = "https://analysis.opencorporates.com".freeze
 
+      PROGRESS_REPORT_FREQUENCY = 5.minutes
+
       RUN_REPORT_PARAMS = %i[
         started_at
         ended_at
@@ -67,6 +69,16 @@ module OpencBot
 
       # DEPRECATED. Please use report_run_to_analysis_app instead of report_run_to_oc
       alias report_run_to_oc report_run_to_analysis_app
+
+      def track_company_processed
+        increment_progress_counters(companies_processed_delta: 1)
+
+        @last_reported_progress ||= Time.new(0)
+        return unless Time.now > @last_reported_progress + PROGRESS_REPORT_FREQUENCY
+
+        report_progress_to_analysis_app
+        @last_reported_progress = Time.now
+      end
 
       def increment_progress_counters(companies_processed_delta: nil)
         @processed_count ||= 0

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -26,10 +26,6 @@ module OpencBot
         report_run_to_analysis_app(results)
       end
 
-      def report_run_progress
-        report_progress_to_analysis_app
-      end
-
       def send_error_report(exception, options = {})
         subject_details = options[:subject_details] || exception
         subject = "Error running #{name}: #{subject_details}"

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -63,7 +63,7 @@ module OpencBot
         run_params.merge!(bot_id: bot_id, bot_type: "external", git_commit: current_git_commit, host: `hostname`.strip)
         run_params[:output] ||= params.to_s unless params.blank?
         _analysis_http_post("#{ANALYSIS_HOST}/runs", run: run_params)
-      rescue Exception => e
+      rescue StandardError => e
         puts "Exception (#{e.inspect}) reporting run to analysis app"
       end
 
@@ -95,7 +95,7 @@ module OpencBot
           "companies_updated" => nil,
         }
         _analysis_http_post("#{ANALYSIS_HOST}/fetcher_progress_log", data: data.to_json)
-      rescue Exception => e
+      rescue StandardError => e
         puts "Exception (#{e.inspect}) reporting progress to analysis app"
       end
 

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -26,8 +26,8 @@ module OpencBot
         report_run_to_analysis_app(results)
       end
 
-      def report_run_progress(companies_processed:, companies_added: nil, companies_updated: nil)
-        report_progress_to_analysis_app(companies_processed: companies_processed, companies_added: companies_added, companies_updated: companies_updated)
+      def report_run_progress
+        report_progress_to_analysis_app
       end
 
       def send_error_report(exception, options = {})
@@ -72,14 +72,19 @@ module OpencBot
       # DEPRECATED. Please use report_run_to_analysis_app instead of report_run_to_oc
       alias report_run_to_oc report_run_to_analysis_app
 
-      def report_progress_to_analysis_app(companies_processed:, companies_added: nil, companies_updated: nil)
+      def increment_progress_counters(companies_processed_delta: nil)
+        @processed_count ||= 0
+        @processed_count += companies_processed_delta
+      end
+
+      def report_progress_to_analysis_app
         return unless reporting_enabled?
 
         data = {
           "bot_id" => to_s.underscore,
-          "companies_processed" => companies_processed,
-          "companies_added" => companies_added,
-          "companies_updated" => companies_updated,
+          "companies_processed" => @processed_count,
+          "companies_added" => nil,
+          "companies_updated" => nil,
         }
         _analysis_http_post("#{ANALYSIS_HOST}/fetcher_progress_log", data: data.to_json)
       rescue Exception => e

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -71,6 +71,8 @@ module OpencBot
       alias report_run_to_oc report_run_to_analysis_app
 
       def track_company_processed
+        StatsD.increment("#{statsd_namespace}.processed", sample_rate: 1.0)
+
         increment_progress_counters(companies_processed_delta: 1)
 
         @last_reported_progress ||= Time.new(0)

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.74".freeze
+  VERSION = "0.0.75".freeze
 end

--- a/spec/lib/openc_bot/helpers/register_methods_spec.rb
+++ b/spec/lib/openc_bot/helpers/register_methods_spec.rb
@@ -280,11 +280,6 @@ describe "a module that includes RegisterMethods" do
       expect(@params).to eq(dup_params)
     end
 
-    it "increments a StatsD counter for this bot" do
-      expect(StatsD).to receive(:increment).with("fetcher_bot.test.modulethatincludesregistermethods.processed", sample_rate: 1.0)
-      ModuleThatIncludesRegisterMethods.prepare_and_save_data(@params)
-    end
-
     it "calls track_company_processed to count and report progress" do
       expect(ModuleThatIncludesRegisterMethods).to receive(:track_company_processed)
       ModuleThatIncludesRegisterMethods.prepare_and_save_data(@params)

--- a/spec/lib/openc_bot/helpers/register_methods_spec.rb
+++ b/spec/lib/openc_bot/helpers/register_methods_spec.rb
@@ -249,6 +249,7 @@ describe "a module that includes RegisterMethods" do
   describe "#prepare_and_save_data" do
     before do
       @params = { name: "Foo Inc", custom_uid: "12345", foo: %w[bar baz], foo2: { bar: "baz" } }
+      allow(ModuleThatIncludesRegisterMethods).to receive(:track_company_processed)
     end
 
     it "insert_or_updates data using primary_key" do
@@ -284,6 +285,11 @@ describe "a module that includes RegisterMethods" do
       ModuleThatIncludesRegisterMethods.prepare_and_save_data(@params)
     end
 
+    it "calls track_company_processed to count and report progress" do
+      expect(ModuleThatIncludesRegisterMethods).to receive(:track_company_processed)
+      ModuleThatIncludesRegisterMethods.prepare_and_save_data(@params)
+    end
+
     it "returns true" do
       expect(ModuleThatIncludesRegisterMethods.prepare_and_save_data(@params)).to be_truthy
     end
@@ -303,6 +309,7 @@ describe "a module that includes RegisterMethods" do
       allow(ModuleThatIncludesRegisterMethods).to receive(:save_data!)
       allow(ModuleThatIncludesRegisterMethods).to receive(:validate_datum).and_return([])
       allow(ModuleThatIncludesRegisterMethods).to receive(:insert_or_update)
+      allow(ModuleThatIncludesRegisterMethods).to receive(:track_company_processed)
     end
 
     it "fetch_datums for company number" do
@@ -811,6 +818,7 @@ describe "a module that includes RegisterMethods" do
   describe "save_entity" do
     before do
       @params = { name: "Foo Inc", custom_uid: "12345", data: { foo: "bar" } }
+      allow(ModuleThatIncludesRegisterMethods).to receive(:track_company_processed)
     end
 
     it "validates entity data" do
@@ -852,6 +860,7 @@ describe "a module that includes RegisterMethods" do
   describe "save_entity!" do
     before do
       @params = { name: "Foo Inc", custom_uid: "12345", data: { foo: "bar" } }
+      allow(ModuleThatIncludesRegisterMethods).to receive(:track_company_processed)
     end
 
     it "validates entity data (excluding :data)" do

--- a/spec/lib/openc_bot/helpers/reporting_spec.rb
+++ b/spec/lib/openc_bot/helpers/reporting_spec.rb
@@ -91,6 +91,7 @@ describe OpencBot::Helpers::Reporting do
   describe "#track_company_processed" do
     before do
       allow(ModuleThatIncludesReporting).to receive(:report_progress_to_analysis_app)
+      allow(StatsD).to receive(:increment)
     end
 
     context "when last_reported_progress has not been initialised (first iteration)" do
@@ -99,6 +100,10 @@ describe OpencBot::Helpers::Reporting do
         ModuleThatIncludesReporting.remove_instance_variable(:@processed_count) if ModuleThatIncludesReporting.instance_variable_defined?(:@processed_count)
 
         ModuleThatIncludesReporting.track_company_processed
+      end
+
+      it "increments a StatsD counter for this bot" do
+        expect(StatsD).to have_received(:increment).with("fetcher_bot.test.modulethatincludesreporting.processed", sample_rate: 1.0)
       end
 
       it "starts the process count" do
@@ -122,6 +127,10 @@ describe OpencBot::Helpers::Reporting do
         ModuleThatIncludesReporting.track_company_processed
       end
 
+      it "increments a StatsD counter for this bot" do
+        expect(StatsD).to have_received(:increment).with("fetcher_bot.test.modulethatincludesreporting.processed", sample_rate: 1.0)
+      end
+
       it "increments the existing process count" do
         expect(ModuleThatIncludesReporting.instance_variable_get(:@processed_count)).to eq(124)
       end
@@ -141,6 +150,10 @@ describe OpencBot::Helpers::Reporting do
         ModuleThatIncludesReporting.instance_variable_set(:@processed_count, 123)
 
         ModuleThatIncludesReporting.track_company_processed
+      end
+
+      it "increments a StatsD counter for this bot" do
+        expect(StatsD).to have_received(:increment).with("fetcher_bot.test.modulethatincludesreporting.processed", sample_rate: 1.0)
       end
 
       it "increments the existing process count" do


### PR DESCRIPTION
Introduce logic to track the progress of a fetcher bot (count of processed companies) and report it to the analysis app every 5 minutes.