### PR TITLE
Restrict reporting to FETCHER_BOT_ENV=production only

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,4 +26,8 @@ Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Metrics/BlockLength:
+  Max: 200
   ExcludedMethods: ["describe", "context"]
+
+Metrics/ModuleLength:
+  Max: 300

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -43,21 +43,12 @@ Lint/UselessAssignment:
 Metrics/AbcSize:
   Max: 32
 
-# Configuration parameters: CountComments, ExcludedMethods.
-# ExcludedMethods: refine
-Metrics/BlockLength:
-  Max: 167
-
 Metrics/CyclomaticComplexity:
   Max: 11
 
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
   Max: 27
-
-# Configuration parameters: CountComments.
-Metrics/ModuleLength:
-  Max: 280
 
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.73)
+    openc_bot (0.0.74)
       activesupport (~> 4.1)
       backports (~> 3.11)
       httpclient (~> 2.8)

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -43,8 +43,12 @@ module OpencBot
       super(default_options.merge(entity_info))
     end
 
-    # wraps #update_data with reporting so that methods can be overridden by company_fetchers
-    # and reporting will still happen (also allows update_data to be run without reporting).
+
+    # This is the main method for running the bot. It is called by cron or
+    # command line using: `bundle exec openc_bot rake bot:run`
+    # It calls #update_data then reports the run result. #update_data might be
+    # overridden by company_fetchers and the final run report will still happen.
+    # Reporting is disabled anyway when FETCHER_BOT_ENV is development/test.
     def run(options = {})
       start_time = Time.now
       update_data_results = update_data(options.merge(started_at: start_time)) || {}
@@ -57,11 +61,9 @@ module OpencBot
       super || "company-schema"
     end
 
-    # this is what is called every time the bot is run using @my_bot.run, or more likely from
-    # cron/command line using: bundle exec openc_bot rake bot:run
-    # It should return some information to be included in the bot run report, and any
-    # that is returned from fetch_data or update_stale (which you should override in preference to
-    # overriding this method) will be included in the run report
+    # Outline bot run logic. Any information that is returned from #fetch_data
+    # or #update_stale (which you should override in preference to overriding
+    # this method) will be returned here and included in the final run report.
     def update_data(options = {})
       fetch_data_results = fetch_data
       update_stale_results = update_stale

--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -43,7 +43,6 @@ module OpencBot
       super(default_options.merge(entity_info))
     end
 
-
     # This is the main method for running the bot. It is called by cron or
     # command line using: `bundle exec openc_bot rake bot:run`
     # It calls #update_data then reports the run result. #update_data might be

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -62,7 +62,7 @@ module OpencBot
 
         bot_id = to_s.underscore
         run_params = params.slice!(RUN_REPORT_PARAMS)
-        run_params.merge!(bot_id: bot_id, bot_type: "external", git_commit: current_git_commit)
+        run_params.merge!(bot_id: bot_id, bot_type: "external", git_commit: current_git_commit, host: `hostname`.strip)
         run_params[:output] ||= params.to_s unless params.blank?
         _analysis_http_post("#{ANALYSIS_HOST}/runs", run: run_params)
       rescue Exception => e

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -17,6 +17,10 @@ module OpencBot
         output
       ].freeze
 
+      def reporting_enabled?
+        ENV["FETCHER_BOT_ENV"] == "production"
+      end
+
       def report_run_results(results)
         send_run_report(results)
         report_run_to_analysis_app(results)
@@ -43,6 +47,8 @@ module OpencBot
       end
 
       def send_report(params)
+        return unless reporting_enabled?
+
         Mail.deliver do
           from "admin@opencorporates.com"
           to "bots@opencorporates.com"
@@ -52,6 +58,8 @@ module OpencBot
       end
 
       def report_run_to_analysis_app(params)
+        return unless reporting_enabled?
+
         bot_id = to_s.underscore
         run_params = params.slice!(RUN_REPORT_PARAMS)
         run_params.merge!(bot_id: bot_id, bot_type: "external", git_commit: current_git_commit)
@@ -65,6 +73,8 @@ module OpencBot
       alias report_run_to_oc report_run_to_analysis_app
 
       def report_progress_to_analysis_app(companies_processed:, companies_added: nil, companies_updated: nil)
+        return unless reporting_enabled?
+
         data = {
           "bot_id" => to_s.underscore,
           "companies_processed" => companies_processed,

--- a/lib/openc_bot/tasks.rb
+++ b/lib/openc_bot/tasks.rb
@@ -95,6 +95,7 @@ namespace :bot do
 
   desc "Update stale data from target"
   task :update_stale do
+    puts "WARNING No FETCHER_BOT_ENV specified" unless ENV["FETCHER_BOT_ENV"]
     only_process_running("update_stale") do
       bot_name = get_bot_name
       require_relative File.join(Dir.pwd, "lib", bot_name)
@@ -105,6 +106,7 @@ namespace :bot do
 
   desc "Run bot, but just for record with given uid"
   task :run_for_uid, :uid do |t, args|
+    puts "WARNING No FETCHER_BOT_ENV specified" unless ENV["FETCHER_BOT_ENV"]
     bot_name = get_bot_name
     only_process_running("#{bot_name}-#{t.name}-#{args[:uid]}") do
       require_relative File.join(Dir.pwd, "lib", bot_name)

--- a/lib/openc_bot/tasks.rb
+++ b/lib/openc_bot/tasks.rb
@@ -59,7 +59,7 @@ namespace :bot do
         require_relative File.join(Dir.pwd, "lib", bot_name)
         runner = callable_from_file_name(bot_name)
 
-        count = runner.update_data(options)
+        count = runner.run(options)
 
         puts "Got #{count} records"
       end

--- a/lib/openc_bot/tasks.rb
+++ b/lib/openc_bot/tasks.rb
@@ -28,6 +28,9 @@ namespace :bot do
   desc "Perform a fetcher bot update_data run without reporting and with dev/debug options"
   task :run do |t, args|
     bot_name = get_bot_name
+    puts "Starting a #{bot_name} update_data run without reporting (dev/debug)"
+    raise "The dev/debug 'run' task should only be invoked with FETCHER_BOT_ENV=development" unless ENV["FETCHER_BOT_ENV"] == "development"
+
     begin
       only_process_running("#{bot_name}-#{t.name}") do
         options = {}
@@ -70,6 +73,8 @@ namespace :bot do
   desc "Perform a fetcher bot run with reporting (Used for real production runs)"
   task :run2 do |_t, _args|
     bot_name = get_bot_name
+    raise "The 'run2' task should only be invoked with FETCHER_BOT_ENV=production" unless ENV["FETCHER_BOT_ENV"] == "production"
+
     begin
       only_process_running("#{bot_name}-bot:run") do
         options = {}

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.73".freeze
+  VERSION = "0.0.74".freeze
 end

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -18,6 +18,7 @@ describe "A module that extends CompanyFetcherBot" do
   before do
     @dummy_connection = double("database_connection", save_data: nil)
     allow(TestCompaniesFetcher).to receive(:sqlite_magic_connection).and_return(@dummy_connection)
+    allow(TestCompaniesFetcher).to receive(:reporting_enabled?).and_return(true)
     allow(TestCompaniesFetcher).to receive(:_analysis_http_post)
   end
 


### PR DESCRIPTION
Start using FETCHER_BOT_ENV to restrict certain actions (reporting to analysis app!) to production only.

Changes to either force or at least encourage the correct setting of FETCHER_BOT_ENV.

https://opencorporates.atlassian.net/browse/OCD-2043

Note: Ultimately it would be cleaner to default to `FETCHER_BOT_ENV=development` so the forcing error message is temporary while we get used to setting it, while we makes sure it is set in all the places this is invoked, and while we add more reasons for setting it (Coming soon I plan to add things which _would_ make it more obvious if we were running in development when we wanted production)