### PR TITLE
Fix e name bug

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -109,6 +109,7 @@ RSpec/ExampleLength:
     - 'spec/lib/openc_bot/helpers/dates_spec.rb'
     - 'spec/lib/openc_bot/helpers/incremental_search_spec.rb'
     - 'spec/lib/openc_bot/helpers/register_methods_spec.rb'
+    - 'spec/lib/openc_bot/helpers/reporting_spec.rb'
     - 'spec/lib/openc_bot/helpers/text_spec.rb'
     - 'spec/lib/openc_bot/incrementers/common_spec.rb'
     - 'spec/lib/openc_bot_spec.rb'
@@ -138,10 +139,16 @@ RSpec/InstanceVariable:
     - 'spec/lib/openc_bot_spec.rb'
     - 'spec/schemas/company-schema_spec.rb'
 
-# Configuration parameters: .
+# Configuration parameters: EnforcedStyle.
 # SupportedStyles: have_received, receive
 RSpec/MessageSpies:
-  EnforcedStyle: receive
+  Exclude:
+    - 'spec/lib/company_fetcher_bot_spec.rb'
+    - 'spec/lib/openc_bot/helpers/alpha_search_spec.rb'
+    - 'spec/lib/openc_bot/helpers/incremental_search_spec.rb'
+    - 'spec/lib/openc_bot/helpers/register_methods_spec.rb'
+    - 'spec/lib/openc_bot/helpers/reporting_spec.rb'
+    - 'spec/lib/openc_bot_spec.rb'
 
 # Configuration parameters: AggregateFailuresByDefault.
 RSpec/MultipleExpectations:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.72)
+    openc_bot (0.0.73)
       activesupport (~> 4.1)
       backports (~> 3.11)
       httpclient (~> 2.8)

--- a/lib/openc_bot/helpers/reporting.rb
+++ b/lib/openc_bot/helpers/reporting.rb
@@ -29,7 +29,7 @@ module OpencBot
       def send_error_report(exception, options = {})
         subject_details = options[:subject_details] || exception
         subject = "Error running #{name}: #{subject_details}"
-        body = "Error details: #{e.inspect}.\nBacktrace:\n#{exception.backtrace}"
+        body = "Error details: #{exception.inspect}.\nBacktrace:\n#{exception.backtrace}"
         send_report(subject: subject, body: body)
         report_run_to_analysis_app(output: body, status_code: "0", ended_at: Time.now.to_s, started_at: options[:started_at])
       end

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.72".freeze
+  VERSION = "0.0.73".freeze
 end


### PR DESCRIPTION
Fix a bug introduced in 3d58baf . `exception` accidentally renamed `e`.

Add test coverage!