### PR TITLE
Fix statsd jurisdiction codes to include underscores

### DIFF
--- a/lib/openc_bot.rb
+++ b/lib/openc_bot.rb
@@ -84,7 +84,9 @@ module OpencBot
       StatsD.server = "sys1:8125"
       StatsD.logger = Logger.new("/dev/null") if bot_env == :test
 
-      if is_a?(Module)
+      if respond_to?(:inferred_jurisdiction_code)
+        "fetcher_bot.#{bot_env}.#{inferred_jurisdiction_code}"
+      elsif is_a?(Module)
         "fetcher_bot.#{bot_env}.#{name.downcase}"
       else
         "fetcher_bot.#{bot_env}.#{self.class.name.downcase}"

--- a/spec/lib/company_fetcher_bot_spec.rb
+++ b/spec/lib/company_fetcher_bot_spec.rb
@@ -86,6 +86,12 @@ describe "A module that extends CompanyFetcherBot" do
     end
   end
 
+  describe "#statsd_namspace" do
+    it "uses the inferred_jurisdiction_code method defined in this module which to produce valid statsd_namespace and jurisdiction_code in snake_case format" do
+      expect(UsXxCompaniesFetcher.statsd_namespace).to eq("fetcher_bot.test.us_xx")
+    end
+  end
+
   describe "#save_entity" do
     before do
       allow(TestCompaniesFetcher).to receive(:inferred_jurisdiction_code).and_return("ab_cd")


### PR DESCRIPTION
Call the `inferred_jurisdiction_code` method which is defined in `CompanyFetcherBot`.

In practice that method is always available (since all bots are company fetcher bots) but in theory OpencBot::CompanyFetcherBot is optional, and in tests e.g. of the reporting helper where we test out statsd, it is not implemented, hence a seperate test within company_fetcher_bot_spec.