### PR TITLE
Remove required_ruby_version from gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.76)
+    openc_bot (0.0.77)
       activesupport (~> 4.1)
       backports (~> 3.11)
       httpclient (~> 2.8)

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,3 +1,3 @@
 module OpencBot
-  VERSION = "0.0.76".freeze
+  VERSION = "0.0.77".freeze
 end

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = "~> 2.2.0"
   gem.add_dependency "activesupport", "~> 4.1"
   gem.add_dependency "backports", "~> 3.11"
   gem.add_dependency "httpclient", "~> 2.8"


### PR DESCRIPTION
We've acceptance tested our in-house bots on 2_6_3, so we can remove the required ruby version in openc_bot to allow bots to run with the newer Ruby version.