### PR TITLE
(WIP - not to be merged) - inspired by machine; flow changes for ELT approach

### DIFF
--- a/lib/openc_bot/company_fetcher_bot_v1.rb
+++ b/lib/openc_bot/company_fetcher_bot_v1.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "openc_bot/company_fetcher_bot"
+require "openc_bot/helpers/dataset_based"
+
+module OpencBot
+  # Extending the behaviour for the CompanyFetcherBot
+  module CompanyFetcherBotV1
+    include OpencBot::Helpers::DatasetBased
+    include OpencBot::CompanyFetcherBot
+
+    ACQUISITION_ID = ENV["ACQUISITION_ID"] || Time.now.to_i
+    ACQUISITION_DIRECTORY = "#{ENV['ACQUISITION_DIRECTORY'] || 'data'}/#{ACQUISITION_ID}"
+    @added = 0
+    @updated = 0
+
+    # Outline bot run logic. Any information that is returned from #fetch_data
+    # or #update_stale (which you should override in preference to overriding
+    # this method) will be returned here and included in the final run report.
+    def update_data(options = {})
+      result = fetch_data.merge(update_stale)
+      result.update(added: @added) unless result.key?(:added)
+      result.update(updated: @updated) unless result.key?(:added)
+      raise "\n#{JSON.pretty_generate(result)}" if result.key?(:fetch_data_error) || result.key?(:update_stale_error)
+
+      result
+    rescue StandardError => e
+      send_error_report(e, options)
+      raise e
+    end
+  end
+end

--- a/lib/openc_bot/helpers/alpha_search.rb
+++ b/lib/openc_bot/helpers/alpha_search.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "openc_bot/helpers/register_methods"
+require "openc_bot/helpers/register_methods_v1"
 
 module OpencBot
   module Helpers
     module AlphaSearch
-      include OpencBot::Helpers::RegisterMethods
+      include OpencBot::Helpers::RegisterMethodsV1
 
       def alpha_terms(starting_term = nil)
         all_perms = letters_and_numbers.repeated_permutation(numbers_of_chars_in_search)

--- a/lib/openc_bot/helpers/dataset_based.rb
+++ b/lib/openc_bot/helpers/dataset_based.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "openc_bot/helpers/register_methods_v1"
+
+module OpencBot
+  module Helpers
+    # Helper which helps in orchestrating the ELT flow of the dataset either available via opendata or procured
+    module DatasetBased
+      extend OpencBot::Helpers::RegisterMethodsV1
+      def fetch_data_via_dataset
+        # Parser, Fetcher & Transformer are the classes that are to be defined by the bot
+        Parser.new.run(Fetcher.new.run).each do |entry|
+          datum = Transformer.new.run(entry)
+          save_entity!(datum)
+        end
+        {}
+      end
+    end
+  end
+end

--- a/lib/openc_bot/helpers/fetcher.rb
+++ b/lib/openc_bot/helpers/fetcher.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "openc_bot/helpers/handler"
+module OpencBot
+  module Helpers
+    # Fetching activities
+    class Fetcher
+      prepend OpencBot::Helpers::Handler
+    end
+  end
+end

--- a/lib/openc_bot/helpers/handler.rb
+++ b/lib/openc_bot/helpers/handler.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module OpencBot
+  module Helpers
+    # Activity tracker
+    module Handler
+      def persist(context, res)
+        FileUtils.mkdir(OpencBot::CompanyFetcherBotV1::ACQUISITION_DIRECTORY) unless File.exist?(OpencBot::CompanyFetcherBotV1::ACQUISITION_DIRECTORY)
+        IO.write("#{OpencBot::CompanyFetcherBotV1::ACQUISITION_DIRECTORY}/#{context}.json", "#{res.to_json}\n", mode: "a")
+      end
+
+      def run(payload = nil)
+        context = self.class.name.split("::").last.downcase
+        result = super
+        if result.instance_of?(Array)
+          result.each do |res|
+            persist(context, res)
+          end
+        else
+          persist(context, result)
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/openc_bot/helpers/incremental_search.rb
+++ b/lib/openc_bot/helpers/incremental_search.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require "openc_bot/helpers/register_methods"
+require "openc_bot/helpers/register_methods_v1"
 
 module OpencBot
   module Helpers
     module IncrementalSearch
-      include OpencBot::Helpers::RegisterMethods
+      include OpencBot::Helpers::RegisterMethodsV1
 
       # Gets new records using an incremental search
       def fetch_data_via_incremental_search(options = {})

--- a/lib/openc_bot/helpers/parser.rb
+++ b/lib/openc_bot/helpers/parser.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "openc_bot/helpers/handler"
+module OpencBot
+  module Helpers
+    # Parser activities
+    class Parser
+      prepend OpencBot::Helpers::Handler
+    end
+  end
+end

--- a/lib/openc_bot/helpers/register_methods_v1.rb
+++ b/lib/openc_bot/helpers/register_methods_v1.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "openc_bot/helpers/register_methods"
+module OpencBot
+  module Helpers
+    # Extending the behaviour for the CompanyFetcherBot
+    module RegisterMethodsV1
+      include OpencBot::Helpers::RegisterMethods
+
+      def dataset_based
+        const_defined?("DATASET_BASED") && const_get("DATASET_BASED")
+      end
+
+      def update_stale(stale_count = nil)
+        count = 0
+        stale_entry_uids(stale_count) do |stale_entry_uid|
+          update_datum(stale_entry_uid)
+          count += 1
+        end
+        { updated: count, stale: assess_stale }
+      rescue OpencBot::OutOfPermittedHours, OpencBot::SourceClosedForMaintenance, Interrupt, SystemExit => e
+        { updated: count, stale: assess_stale, update_stale_output: { error: exception_to_object(e) } }
+      rescue StandardError => e
+        { updated: count, stale: assess_stale, update_stale_error: { error: exception_to_object(e) } }
+      end
+
+      def fetch_data
+        original_count = record_count
+        res = {}
+        if use_alpha_search
+          fetch_data_via_alpha_search
+          res[:run_type] = "alpha"
+        elsif dataset_based
+          fetch_data_via_dataset
+          res[:run_type] = "dataset"
+        else
+          new_highest_numbers = fetch_data_via_incremental_search
+          res[:run_type] = "incremental"
+          res[:output] = "New highest numbers = #{new_highest_numbers.inspect}"
+        end
+        records_added = record_count - original_count
+        res.merge(added: records_added)
+      rescue OpencBot::OutOfPermittedHours, OpencBot::SourceClosedForMaintenance, Interrupt, SystemExit => e
+        res.merge!({ fetch_data_output: { error: exception_to_object(e) } })
+      rescue StandardError => e
+        res.merge!({ fetch_data_error: { error: exception_to_object(e) } })
+      end
+
+      def exception_to_object(exp)
+        { klass: exp.class.to_s, message: exp.message, backtrace: exp.backtrace }
+      end
+    end
+  end
+end

--- a/lib/openc_bot/helpers/transformer.rb
+++ b/lib/openc_bot/helpers/transformer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "openc_bot/helpers/handler"
+module OpencBot
+  module Helpers
+    # Transformation activities
+    class Transformer
+      prepend OpencBot::Helpers::Handler
+    end
+  end
+end
+


### PR DESCRIPTION
The following changes are made to the flow.
a) Now a new flag called `DATASET_BASED` is added which will support activity handled of bulk data files
The flow of it is: Parser will be called with output from Fetcher & Transformer will be called with output(s) from Parser.
b) Fetch_data and Update_Stale now have resilience in the case of failures built in
c) 3 rake tasks have been created

```
i) FETCHER_BOT_ENV=development bundle exec openc_bot rake bot:fetch
```
Which will only deal with fetching of bulk data files from registry

```
ii) FETCHER_BOT_ENV=development bundle exec openc_bot rake bot:parse\['1616185536']
```
Which will take the acquisition_id as parameter and does parsing of fetched files

```
iii) FETCHER_BOT_ENV=development bundle exec openc_bot rake bot:transform\['1616185536']
```
Which will take the acquisition_id as parameter and does tranformation of parsed files