### PR TITLE
change sqlite dependency for less than 1.6

### DIFF
--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sqlite_magic", "0.0.6"
   gem.add_dependency "statsd-instrument", "~> 1.7"
   gem.add_dependency "tzinfo", "~> 1.2"
-  gem.add_dependency "sqlite3", "1.5.3"
+  gem.add_dependency "sqlite3", "< 1.6"
 
   # gem.add_development_dependency "perftools.rb"
   gem.add_development_dependency "byebug", "~> 10.0"


### PR DESCRIPTION
earlier we set the sqlite3 dependency to 1.5.3 and a few gems were not compatible with this version of sqlite3. SO we are setting the dependency to less than 1.6 so that if the gems want to use the lower version they can.