### PR TITLE
Change CodeOwners for openc_bot gem

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @harry-wood @tullis @alexpapworth @alanbuxton @lizconlan @ivanbashkirov
+@tech-codeowners


### PR DESCRIPTION
setting the code owners to https://github.com/openc/iac-github/blob/master/teams/team-tech-codeowners.tf