### PR TITLE
DA-1083 Handle exceptions from get AWS secret step.

### DIFF
--- a/lib/openc_bot.rb
+++ b/lib/openc_bot.rb
@@ -37,6 +37,9 @@ module OpencBot
     # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
     secret = get_secret_value_response.secret_string
     JSON.parse(secret)
+  rescue Exception => e
+    send_error_report(e)
+    raise e
   end
 
   def default_aws_region


### PR DESCRIPTION
Related ticket: https://opencorporates.atlassian.net/browse/DA-1083
Update: 
- Handle exceptions and send to analysis app when get_bot_secret failed