### PR TITLE
fix(TECH-2652): fix inferred_jurisdiction_code

### DIFF
--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -23,7 +23,7 @@ module OpencBot
 
     def inferred_jurisdiction_code
       poss_j_code = name.sub(/CompaniesFetcher/, "").underscore
-      poss_j_code[/^[a-z]{2}$|^[a-z]{2}_[a-z]{2}$/]
+      poss_j_code[/^[a-z]{2}\d?$|^[a-z]{2}_[a-z]{2}\d?$/]
     end
 
     def primary_key_name


### PR DESCRIPTION
if the bot_id has numerical digits, for eg: `fr2`, `us_mt2` etc, then the `inferred_jurisdiction_code` is nil currently. The PR is a fix to properly reflect the `inferred_jurisdiction_code`