### PR TITLE
Update SQLite dependency constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 gem "sqlite_magic", git: "https://github.com/openc/sqlite_magic.git"
 gem "openc_industry_codes", git: "git@github.com:openc/openc_industry_codes.git"
+gem 'sqlite3', '~> 1.4.4'
 
 gem "pry", group: %i[development test]
 # Specify your gem's dependencies in openc_bot.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    openc_bot (0.0.84)
+    openc_bot (0.0.86)
       activesupport (~> 4.1)
       aws-sdk-s3 (~> 1.67)
       aws-sdk-secretsmanager (= 1.9)
@@ -31,7 +31,7 @@ PATH
       resque (~> 2.0)
       retriable (~> 2.1)
       scraperwiki (= 3.0.2)
-      sqlite3 (~> 1.3.0)
+      sqlite3 (< 1.6.0)
       sqlite_magic (= 0.0.6)
       statsd-instrument (~> 1.7)
       tzinfo (~> 1.2)
@@ -48,18 +48,18 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     aws-eventstream (1.3.2)
-    aws-partitions (1.1099.0)
-    aws-sdk-core (3.223.0)
+    aws-partitions (1.1103.0)
+    aws-sdk-core (3.224.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.100.0)
+    aws-sdk-kms (1.101.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.185.0)
+    aws-sdk-s3 (1.186.1)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -79,7 +79,7 @@ GEM
       bigdecimal
       rexml
     date (3.4.1)
-    diff-lcs (1.6.1)
+    diff-lcs (1.6.2)
     hashdiff (1.1.2)
     httpclient (2.9.0)
       mutex_m
@@ -97,7 +97,7 @@ GEM
       net-smtp
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.15.0)
     mono_logger (1.1.2)
     multi_json (1.15.0)
@@ -182,7 +182,7 @@ GEM
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.2.0)
       tilt (~> 2.0)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.4)
     statsd-instrument (1.7.2)
     thread_safe (0.3.6)
     tilt (2.6.0)
@@ -207,8 +207,9 @@ DEPENDENCIES
   rspec (~> 3.8)
   rubocop (~> 0.93.1)
   rubocop-rspec (~> 1.30)
+  sqlite3 (~> 1.4.4)
   sqlite_magic!
   webmock (~> 1.20)
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/lib/openc_bot/version.rb
+++ b/lib/openc_bot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpencBot
-  VERSION = "0.0.85"
+  VERSION = "0.0.86"
 end

--- a/openc_bot.gemspec
+++ b/openc_bot.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "sqlite_magic", "0.0.6"
   gem.add_dependency "statsd-instrument", "~> 1.7"
   gem.add_dependency "tzinfo", "~> 1.2"
-  gem.add_dependency "sqlite3", "~> 1.3.0"
+  gem.add_dependency "sqlite3", "< 1.6.0"
   gem.add_dependency "aws-sdk-secretsmanager", "1.9"
   gem.add_dependency "aws-sdk-s3", "~> 1.67"
   gem.add_dependency "bigdecimal", "~> 1.4.0"


### PR DESCRIPTION
This PR updates the SQLite3 dependency constraints to make the openc_bot gem more compatible with projects that use newer SQLite versions. The previous strict requirement of ~> 1.3.0 was causing version conflicts in downstream repositories, particularly in the external_bots service.

**Changes**
Relaxed SQLite3 version constraint from ~> 1.3.0 to < 1.6.0 in the gemspec
Added explicit SQLite3 ~> 1.4.4 dependency to the Gemfile for development and test purposes 
Bumped gem version from 0.0.85 to 0.0.86
Updated Gemfile.lock to reflect the dependency changes

**Testing**
Local tests run in docker
In external bots for `UsHi`