### PR TITLE
Handle error is_parakeet_bot? for nil class

### DIFF
--- a/lib/openc_bot/company_fetcher_bot.rb
+++ b/lib/openc_bot/company_fetcher_bot.rb
@@ -59,6 +59,7 @@ module OpencBot
       begin
         ingest_file = false
         start_time = Time.now
+        update_data_results = {}
         LOGGER.info({service: "company_fetcher_bot", event:"run_begin", bot_name: bot_name, bot_run_id: bot_run_id}.to_json)
         begin
           update_data_results = update_data(options.merge(started_at: start_time)) || {}


### PR DESCRIPTION
Related ticket: https://opencorporates.atlassian.net/browse/DA-6339?focusedCommentId=139249

We have several non-parakeet bots that override the update_data function.
If update_data raises an error, update_data_results becomes nil, which leads to the following error:
 ``is_parakeet_bot?': undefined method `[]' for nil:NilClass (NoMethodError).`
This error prevents the bot from sending error to analysis app and ingesting the data. 
